### PR TITLE
Updates build to use Makefile and valid scm-source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-main
+build/
 scm-source.json
 resources/random

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM scratch
-
 MAINTAINER Henning Jacobs <henning@jacobs1.de>
 
-COPY main /main
-COPY scm-source.json /
+# add scm-source
+ADD scm-source.json /
 
-CMD ["/main"]
+# add binary
+ADD build/linux/tiny-docker-http-test /
+
+CMD ["/tiny-docker-http-test"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,51 @@
+.PHONY: clean check build.local build.linux build.osx build.docker build.push
+
+BINARY        		 ?= tiny-docker-http-test
+VERSION       		 ?= $(shell git describe --tags --always --dirty)
+IMAGE         		 ?= hjacobs/$(BINARY)
+TAG           		 ?= $(VERSION)
+GITHEAD       		 = $(shell git rev-parse --short HEAD)
+GITURL        		 = $(shell git config --get remote.origin.url)
+GITSTATUS     		 = $(shell git status --porcelain || echo "no changes")
+SOURCES       		 = $(shell find . -name '*.go')
+DOCKERFILE    		 ?= Dockerfile
+GOPKGS        		 = $(shell go list ./... | grep -v /vendor/)
+BUILD_FLAGS   		 ?= -v
+LDFLAGS       		 ?= -X main.version=$(VERSION) -w -s
+
+default: build.local
+
+clean:
+	rm -rf build
+
+test:
+	go test -v -race $(GOPKGS)
+
+fmt:
+	go fmt $(GOPKGS)
+
+check:
+	golint $(GOPKGS)
+	go vet -v $(GOPKGS)
+
+build.local: build/$(BINARY)
+build.linux: build/linux/$(BINARY)
+build.osx: build/osx/$(BINARY)
+
+build/$(BINARY): $(SOURCES)
+	CGO_ENABLED=0 go build -o build/$(BINARY) $(BUILD_FLAGS) -ldflags "$(LDFLAGS)" .
+
+build/linux/$(BINARY): $(SOURCES)
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/linux/$(BINARY) -ldflags "$(LDFLAGS)" .
+
+build/osx/$(BINARY): $(SOURCES)
+	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/osx/$(BINARY) -ldflags "$(LDFLAGS)" .
+
+build.docker: scm-source.json build.linux #zalando compliant image
+	docker build --rm -t "$(IMAGE):$(TAG)" -f $(DOCKERFILE) .
+
+build.push: build.docker
+	docker push "$(IMAGE):$(TAG)"
+
+scm-source.json: .git
+	@echo '{"url": "git:$(GITURL)", "revision": "$(GITHEAD)", "author": "$(USER)", "status": "$(GITSTATUS)"}' > scm-source.json

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,5 @@ It is mentioned to be used for testing docker inside docker functionality.
 .. code-block:: bash
 
     $ # build a completely static Go binary
-    $ CGO_ENABLED=0 go build -a -ldflags '-s' main.go
-    $ sudo pip3 install scm-source && scm-source
-    $ docker build -t hjacobs/tiny-docker-http-test .
+    $ make build.docker
     $ docker run -p 8080:8080 -it hjacobs/tiny-docker-http-test


### PR DESCRIPTION
* Use Makefile for build
* Generate valid `scm-source.json` (is it actually valid if it comes from your repo?)